### PR TITLE
Add Foundation CDN, back link, and fix guide href

### DIFF
--- a/games/dbz-legendary-super-warriors.html
+++ b/games/dbz-legendary-super-warriors.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>DBZ: Legendary Super Warriors — Guide</title>
 <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.8.1/dist/css/foundation.min.css">
 <style>
   :root {
     --bg: #0a0c10;
@@ -347,6 +348,8 @@
 </head>
 <body>
 <div class="shell">
+
+  <a href="../index.html" style="display:inline-block;font-family:'Press Start 2P',monospace;font-size:8px;color:var(--text-dim);text-decoration:none;padding:10px 0 0;letter-spacing:1px;">&#8592; Pocket Guides</a>
 
   <header>
     <div class="game-label">Game Boy Advance · RPG</div>

--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
 
       <div class="cell small-6 medium-4 large-3 game-card"
            data-name="dragon ball z legendary super warriors game boy advance rpg gba dbz">
-        <a href="games/dbz-legendary-super-warriors/">
+        <a href="games/dbz-legendary-super-warriors.html">
           <img src="assets/img/dbz-lsw-boxart.svg"
                alt="Dragon Ball Z: Legendary Super Warriors box art">
           <div class="game-card-info">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add Foundation 6 CSS CDN to the guide page
- Add "← Pocket Guides" back link above the guide header
- Fix `index.html` href pointing at the empty directory instead of `games/dbz-legendary-super-warriors.html`

## Test plan

- [ ] Landing page card links correctly to the guide
- [ ] Guide page loads with Foundation CSS in the head
- [ ] Back link navigates to the landing page
EOF
)