### PR TITLE
Add Donkey Kong (Game Boy, 1994) guide

### DIFF
--- a/assets/img/donkey-kong-gb-boxart.svg
+++ b/assets/img/donkey-kong-gb-boxart.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 280" width="200" height="280">
+  <rect width="200" height="280" fill="#0a0c10"/>
+  <!-- Sky gradient -->
+  <rect width="200" height="160" fill="#1a1000"/>
+  <!-- Scaffolding lines -->
+  <line x1="30" y1="20" x2="30" y2="160" stroke="#2a3040" stroke-width="3"/>
+  <line x1="80" y1="20" x2="80" y2="160" stroke="#2a3040" stroke-width="3"/>
+  <line x1="130" y1="20" x2="130" y2="160" stroke="#2a3040" stroke-width="3"/>
+  <line x1="170" y1="20" x2="170" y2="160" stroke="#2a3040" stroke-width="3"/>
+  <line x1="20" y1="60" x2="180" y2="60" stroke="#2a3040" stroke-width="2"/>
+  <line x1="20" y1="100" x2="180" y2="100" stroke="#2a3040" stroke-width="2"/>
+  <line x1="20" y1="140" x2="180" y2="140" stroke="#2a3040" stroke-width="2"/>
+  <!-- DK silhouette -->
+  <ellipse cx="100" cy="70" rx="30" ry="28" fill="#c8691a"/>
+  <ellipse cx="100" cy="68" rx="22" ry="20" fill="#e07820"/>
+  <!-- DK face -->
+  <ellipse cx="100" cy="72" rx="18" ry="14" fill="#c07020"/>
+  <circle cx="92" cy="66" r="5" fill="#111318"/>
+  <circle cx="108" cy="66" r="5" fill="#111318"/>
+  <circle cx="93" cy="65" r="2" fill="#f4a800"/>
+  <circle cx="109" cy="65" r="2" fill="#f4a800"/>
+  <ellipse cx="100" cy="76" rx="10" ry="6" fill="#b06010"/>
+  <!-- DK arms -->
+  <ellipse cx="68" cy="78" rx="14" ry="8" fill="#c8691a" transform="rotate(-20,68,78)"/>
+  <ellipse cx="132" cy="78" rx="14" ry="8" fill="#c8691a" transform="rotate(20,132,78)"/>
+  <!-- Ground/platform -->
+  <rect x="0" y="160" width="200" height="120" fill="#111318"/>
+  <rect x="0" y="158" width="200" height="6" fill="#f4a800"/>
+  <!-- Mario (small) on ground -->
+  <rect x="30" y="175" width="12" height="16" fill="#ff4444"/>
+  <rect x="32" y="170" width="8" height="8" fill="#f4a800"/>
+  <rect x="30" y="183" width="5" height="8" fill="#4a3000"/>
+  <rect x="37" y="183" width="5" height="8" fill="#4a3000"/>
+  <!-- Title area -->
+  <rect x="0" y="205" width="200" height="75" fill="#0a0c10"/>
+  <rect x="0" y="205" width="200" height="2" fill="#f4a800" opacity="0.3"/>
+  <!-- Title text -->
+  <text x="100" y="228" font-family="monospace" font-size="22" font-weight="bold" fill="#f4a800" text-anchor="middle" letter-spacing="2">DONKEY</text>
+  <text x="100" y="250" font-family="monospace" font-size="22" font-weight="bold" fill="#f4a800" text-anchor="middle" letter-spacing="2">KONG</text>
+  <!-- Platform label -->
+  <text x="100" y="270" font-family="monospace" font-size="9" fill="#4fc3f7" text-anchor="middle" letter-spacing="3">GAME BOY · 1994</text>
+</svg>

--- a/games/donkey-kong-gb.html
+++ b/games/donkey-kong-gb.html
@@ -1,0 +1,567 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Donkey Kong (Game Boy) — Guide</title>
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.8.1/dist/css/foundation.min.css">
+<style>
+  :root {
+    --bg: #0a0c10;
+    --surface: #111318;
+    --surface2: #181c24;
+    --border: #2a3040;
+    --accent: #f4a800;
+    --accent2: #ff4444;
+    --accent3: #4fc3f7;
+    --text: #d8dde8;
+    --text-dim: #7a8599;
+    --glow: 0 0 12px rgba(244,168,0,0.3);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 14px;
+    line-height: 1.7;
+    min-height: 100vh;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(0,0,0,0.08) 2px,
+      rgba(0,0,0,0.08) 4px
+    );
+    pointer-events: none;
+    z-index: 1000;
+  }
+
+  .shell {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 16px 60px;
+  }
+
+  header {
+    padding: 40px 0 24px;
+    border-bottom: 2px solid var(--accent);
+    margin-bottom: 32px;
+    position: relative;
+  }
+
+  header::after {
+    content: '';
+    display: block;
+    height: 1px;
+    background: var(--accent3);
+    margin-top: 4px;
+    opacity: 0.3;
+  }
+
+  .game-label {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 9px;
+    color: var(--accent3);
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+    opacity: 0.7;
+  }
+
+  h1 {
+    font-family: 'Press Start 2P', monospace;
+    font-size: clamp(13px, 3vw, 20px);
+    color: var(--accent);
+    text-shadow: var(--glow);
+    line-height: 1.5;
+    letter-spacing: 1px;
+  }
+
+  .subtitle {
+    color: var(--text-dim);
+    font-size: 12px;
+    margin-top: 10px;
+  }
+
+  nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 32px;
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: 10px 0;
+    z-index: 100;
+    border-bottom: 1px solid var(--border);
+  }
+
+  nav a {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 8px;
+    color: var(--text-dim);
+    text-decoration: none;
+    padding: 6px 10px;
+    border: 1px solid var(--border);
+    transition: all 0.15s;
+    background: var(--surface);
+  }
+
+  nav a:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--surface2);
+    box-shadow: var(--glow);
+  }
+
+  section {
+    margin-bottom: 48px;
+    scroll-margin-top: 70px;
+  }
+
+  h2 {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 12px;
+    color: var(--accent);
+    text-shadow: var(--glow);
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 20px;
+    letter-spacing: 1px;
+  }
+
+  h3 {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 9px;
+    color: var(--accent3);
+    margin: 20px 0 10px;
+    letter-spacing: 1px;
+  }
+
+  p { margin-bottom: 12px; color: var(--text); }
+
+  .tbl-wrap { overflow-x: auto; margin-bottom: 16px; }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+
+  th {
+    background: var(--surface2);
+    color: var(--accent);
+    font-family: 'Press Start 2P', monospace;
+    font-size: 8px;
+    padding: 8px 12px;
+    text-align: left;
+    border: 1px solid var(--border);
+    letter-spacing: 1px;
+  }
+
+  td {
+    padding: 7px 12px;
+    border: 1px solid var(--border);
+    vertical-align: top;
+    color: var(--text);
+  }
+
+  tr:nth-child(even) td { background: rgba(255,255,255,0.02); }
+  tr:hover td { background: rgba(244,168,0,0.04); }
+
+  .info-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent3);
+    padding: 12px 16px;
+    margin-bottom: 16px;
+  }
+
+  .info-box p { margin: 0; }
+
+  .warn-box {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    padding: 12px 16px;
+    margin-bottom: 16px;
+  }
+
+  .warn-box p { margin: 0; }
+
+  code {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    padding: 1px 5px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 12px;
+    color: var(--accent3);
+  }
+
+  .world-list { display: flex; flex-direction: column; gap: 8px; }
+
+  .world-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    padding: 12px 16px;
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  .world-num {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 7px;
+    color: var(--text-dim);
+    min-width: 60px;
+    flex-shrink: 0;
+  }
+
+  .world-name {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 9px;
+    color: var(--accent);
+    min-width: 140px;
+  }
+
+  .world-desc {
+    color: var(--text);
+    font-size: 13px;
+  }
+
+  .move-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
+
+  .move-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 10px 14px;
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 12px;
+    align-items: start;
+  }
+
+  .move-input {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 8px;
+    color: var(--accent3);
+    line-height: 1.8;
+  }
+
+  .move-desc {
+    font-size: 13px;
+    color: var(--text);
+  }
+
+  @media (max-width: 560px) {
+    h1 { font-size: 11px; }
+    .move-card { grid-template-columns: 1fr; }
+    .world-card { flex-direction: column; gap: 4px; }
+  }
+
+  .tag {
+    display: inline-block;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 7px;
+    padding: 2px 6px;
+    background: var(--surface2);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+
+  .tag-cyan {
+    border-color: var(--accent3);
+    color: var(--accent3);
+  }
+
+  .warn { color: var(--accent); font-weight: bold; }
+
+  ul.bullet-list {
+    list-style: none;
+    margin-bottom: 12px;
+  }
+
+  ul.bullet-list li::before {
+    content: '▸ ';
+    color: var(--accent);
+  }
+
+  ul.bullet-list li {
+    margin-bottom: 4px;
+  }
+
+  footer {
+    border-top: 1px solid var(--border);
+    padding: 20px 0;
+    color: var(--text-dim);
+    font-size: 11px;
+    margin-top: 40px;
+  }
+</style>
+</head>
+<body>
+<div class="shell">
+
+  <a href="../index.html" style="display:inline-block;font-family:'Press Start 2P',monospace;font-size:8px;color:var(--text-dim);text-decoration:none;padding:10px 0 0;letter-spacing:1px;">&#8592; Pocket Guides</a>
+
+  <header>
+    <div class="game-label">Game Boy · Platformer</div>
+    <h1>Donkey Kong</h1>
+    <p class="subtitle">Nintendo · Original Game Boy · 1994</p>
+  </header>
+
+  <nav>
+    <a href="#overview">Overview</a>
+    <a href="#controls">Controls</a>
+    <a href="#moves">Moves</a>
+    <a href="#worlds">Worlds</a>
+    <a href="#tips">Tips</a>
+    <a href="#secrets">Secrets</a>
+  </nav>
+
+  <!-- OVERVIEW -->
+  <section id="overview">
+    <h2>Overview</h2>
+    <p>This 1994 Game Boy title begins as a faithful recreation of the original arcade game — 25th Floor, 50th Floor, 75th Floor, and 100th Floor — but once Donkey Kong escapes after the opening, the game expands into a full platformer spanning nine additional worlds.</p>
+    <p>Mario pursues DK across the globe to rescue Pauline. Each stage follows the same structure: find the <strong>key</strong>, carry it to the <strong>locked door</strong> at the exit. Mario has a vastly expanded moveset compared to the arcade original, making mobility and acrobatics core to the game.</p>
+    <div class="info-box">
+      <p><strong>Key mechanic:</strong> If Mario drops the key and it falls off-screen, or the timer runs out while carrying it, the key resets to its original position. You cannot complete a stage without the key.</p>
+    </div>
+  </section>
+
+  <!-- CONTROLS -->
+  <section id="controls">
+    <h2>Controls</h2>
+    <div class="tbl-wrap">
+      <table>
+        <thead><tr><th>Button</th><th>Action</th></tr></thead>
+        <tbody>
+          <tr><td>D-Pad Left / Right</td><td>Walk. Hold the direction after the first step to run.</td></tr>
+          <tr><td>D-Pad Up</td><td>Climb a ladder or rope upward. Pull up from a ledge.</td></tr>
+          <tr><td>D-Pad Down</td><td>Duck. Climb a ladder or rope downward.</td></tr>
+          <tr><td>A</td><td>Jump. Hold longer for a higher jump.</td></tr>
+          <tr><td>B</td><td>Pick up an object. Grab a rope or ledge edge.</td></tr>
+          <tr><td>A (while carrying)</td><td>Throw the held object in a forward arc.</td></tr>
+          <tr><td>Start</td><td>Pause / unpause.</td></tr>
+          <tr><td>Select</td><td>Not used during gameplay.</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- MOVES -->
+  <section id="moves">
+    <h2>Moves</h2>
+    <p>Mario's expanded moveset is what sets this game apart from the arcade original. Learning all of these is essential for later worlds.</p>
+
+    <div class="move-list">
+
+      <div class="move-card">
+        <div class="move-input">A</div>
+        <div class="move-desc"><strong>Jump.</strong> Hold A longer to reach greater heights. The jump arc is fixed horizontally — plan your approach.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">Run + A</div>
+        <div class="move-desc"><strong>Long Jump.</strong> Running before pressing A extends horizontal distance significantly. Required to cross many gaps in later worlds.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">Down → A<br>(while standing still)</div>
+        <div class="move-desc"><strong>Backflip.</strong> Press Down then immediately press A without moving. Mario leaps backward (opposite to his facing direction) with a higher arc than a normal jump. Useful for reaching platforms behind you or clearing tall obstacles.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">Down (hold)</div>
+        <div class="move-desc"><strong>Crouch / Duck.</strong> Mario crouches to pass under low obstacles. Also used to slide down from ropes at speed.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">Jump toward ledge edge</div>
+        <div class="move-desc"><strong>Ledge Grab.</strong> If Mario reaches the edge of a platform at the right height, he automatically grabs and hangs from it. Press Up or A to pull up onto the platform.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">B at ledge edge<br>(while hanging)</div>
+        <div class="move-desc"><strong>Handstand.</strong> While hanging from a ledge, press the appropriate direction to do a handstand on top of the edge. From the handstand position Mario can jump higher than normal, reaching platforms above that a regular pull-up would not reach.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">Up / Down near rope or ladder</div>
+        <div class="move-desc"><strong>Climb.</strong> Mario grabs ropes, chains, and ladders automatically when adjacent. Use Up and Down to ascend or descend. Jumping from the very top of a ladder gives a small height bonus.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">B near object</div>
+        <div class="move-desc"><strong>Pick Up.</strong> Grabs keys, hammers, barrels, crates, and other interactive objects. Mario can carry one item at a time.</div>
+      </div>
+
+      <div class="move-card">
+        <div class="move-input">A while carrying</div>
+        <div class="move-desc"><strong>Throw.</strong> Launches the held item forward in an arc. Used to hit enemies or activate distant switches. Timing and distance take practice.</div>
+      </div>
+
+    </div>
+
+    <div class="info-box">
+      <p><strong>Carrying the key:</strong> Mario moves and jumps normally while holding the key. You can still fight enemies and use most moves. The key drops if Mario is hit by certain attacks — retrieve it before it falls off the stage.</p>
+    </div>
+  </section>
+
+  <!-- WORLDS -->
+  <section id="worlds">
+    <h2>Worlds</h2>
+    <p>After the four Big City stages mirror the original arcade game, DK escapes and the full world tour begins. Each world introduces new hazards and obstacles built around Mario's moveset.</p>
+
+    <div class="world-list">
+      <div class="world-card">
+        <span class="world-num">WORLD 1</span>
+        <span class="world-name">Big City</span>
+        <span class="world-desc">The four arcade stages: 25th Floor, 50th Floor, 75th Floor, and 100th Floor. Rolling barrels, fireballs, rivets. Beats the original arcade game, then DK flees.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 2</span>
+        <span class="world-name">Rocky-Valley</span>
+        <span class="world-desc">Rocky mountain terrain. Introduces moving platforms and enemies that require the new jump and throw mechanics. First test of the expanded moveset.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 3</span>
+        <span class="world-name">Ship</span>
+        <span class="world-desc">An ocean vessel. Slippery surfaces, ropes, and tight vertical climbs. Carrying the key through narrow passages requires precise ledge grabs.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 4</span>
+        <span class="world-name">Jungle</span>
+        <span class="world-desc">Dense vegetation with vines to swing on and animal enemies. Long jumps across gaps are frequently required. A good world to practice the backflip.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 5</span>
+        <span class="world-name">Airplane</span>
+        <span class="world-desc">Stages set on and inside aircraft. Moving platforms, propeller hazards, and wind effects that push Mario mid-jump. Timing is critical.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 6</span>
+        <span class="world-name">Iceberg</span>
+        <span class="world-desc">Slippery ice floors that reduce traction. Mario slides when landing, making key-carry sequences more demanding. Walrus-type enemies appear.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 7</span>
+        <span class="world-name">Rocky-Valley 2</span>
+        <span class="world-desc">A return to rocky terrain with significantly harder layouts. Handstand jumps and precise long jumps become mandatory to progress.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">WORLD 8</span>
+        <span class="world-name">Tower</span>
+        <span class="world-desc">The longest world — a tall tower with many floors, conveyor belts, and complex enemy patterns. All of Mario's moves are put to the test here.</span>
+      </div>
+      <div class="world-card">
+        <span class="world-num">FINAL</span>
+        <span class="world-name">DK's Domain</span>
+        <span class="world-desc">The final confrontation with Donkey Kong. Multi-phase boss fight: hit the switches to damage DK while avoiding his attacks. Each phase adds new patterns.</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- TIPS -->
+  <section id="tips">
+    <h2>Tips &amp; Strategy</h2>
+
+    <h3>Key Handling</h3>
+    <ul class="bullet-list">
+      <li>Scout the full stage layout <em>before</em> picking up the key — know your route.</li>
+      <li>You can throw the key across a gap and then jump over to retrieve it on the other side.</li>
+      <li>If an enemy is in the way, throw the key past it, deal with the enemy, then recover the key.</li>
+      <li>The key floats briefly after being thrown — you can jump and recatch it mid-air.</li>
+    </ul>
+
+    <h3>Scoring</h3>
+    <ul class="bullet-list">
+      <li><strong>Time Bonus:</strong> Remaining seconds are multiplied and added to your score when you clear a stage. Speed matters for high scores.</li>
+      <li><strong>Point Chests:</strong> Golden chests labeled 100, 200, 500, or 1000 are scattered throughout each stage. Collecting all of them before leaving maximizes your score.</li>
+      <li><strong>Enemy Bonus:</strong> Defeating enemies with thrown objects or hammers scores extra points.</li>
+    </ul>
+
+    <h3>Enemies</h3>
+    <ul class="bullet-list">
+      <li>Many enemies can be defeated by throwing objects at them or stomping.</li>
+      <li>Enemies that cannot be defeated should simply be avoided — don't waste time.</li>
+      <li>The hammer power-up destroys all enemies it touches and is carried like a key.</li>
+    </ul>
+
+    <h3>Extra Lives</h3>
+    <ul class="bullet-list">
+      <li>Accumulate points — lives are awarded at score thresholds.</li>
+      <li>Certain stages contain hidden <strong>heart items</strong> that grant an extra life. Check off-screen areas and push objects to reveal them.</li>
+    </ul>
+
+    <h3>General</h3>
+    <ul class="bullet-list">
+      <li>The game saves via battery backup. Save at every opportunity — especially before difficult stages.</li>
+      <li>Later worlds heavily rely on the backflip and handstand. Practice them in early stages.</li>
+      <li>If you are low on time, drop the key at the door, clear a path, then come back for the key — you cannot open the door without it but you can set it down safely.</li>
+    </ul>
+  </section>
+
+  <!-- SECRETS & CHEATS -->
+  <section id="secrets">
+    <h2>Secrets &amp; Cheats</h2>
+
+    <h3>Pauline's Accessories</h3>
+    <p>During the opening cutscene, Pauline drops her <strong>hat</strong>, <strong>purse</strong>, and <strong>parasol</strong> as DK carries her up the building. These three items appear as collectibles hidden within the first world's stages.</p>
+    <div class="info-box">
+      <p>Collecting all three accessories across the Big City stages rewards a significant score bonus. They reappear on subsequent playthroughs, so veteran players always watch for them.</p>
+    </div>
+
+    <h3>Hidden Hearts (Extra Lives)</h3>
+    <p>Extra life hearts are hidden in several stages throughout the game — not just Big City. Common hiding spots:</p>
+    <ul class="bullet-list">
+      <li>Behind or beneath objects that can be pushed or thrown</li>
+      <li>In alcoves at the edge of the screen that require a ledge grab to reach</li>
+      <li>At the top of ropes that appear to lead nowhere</li>
+      <li>In rooms accessible only by backflipping into an otherwise unreachable gap</li>
+    </ul>
+
+    <h3>Super Game Boy</h3>
+    <p>Playing the cartridge via the <strong>Super Game Boy</strong> accessory on a SNES unlocks two enhancements:</p>
+    <div class="tbl-wrap">
+      <table>
+        <thead><tr><th>Feature</th><th>Details</th></tr></thead>
+        <tbody>
+          <tr><td>Custom border</td><td>A unique illustrated frame featuring Donkey Kong artwork surrounds the game screen.</td></tr>
+          <tr><td>Colour palette</td><td>The game applies custom colour palettes to different screen areas, replacing the standard green Game Boy tones with browns, reds, and blues faithful to the arcade original.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Big City Stage Skip</h3>
+    <p>In the four opening Big City stages, the rivet mechanic from the original arcade is preserved — removing all rivets on a floor causes it to collapse. <span class="warn">You do not need to collect the key on the 100th Floor rivet stage.</span> Knocking out all rivets ends the stage immediately, regardless of whether the key door has been used.</p>
+
+    <h3>Score Exploit — Hammer Loop</h3>
+    <p>On stages where a hammer and a continuous enemy spawn are both present, Mario can repeatedly defeat enemies with the hammer for points. The hammer has a finite duration, but during it enemies killed in quick succession award escalating point values. Useful for farming lives via score on the Big City floors.</p>
+
+    <div class="warn-box">
+      <p><strong>Note on cheat codes:</strong> Donkey Kong (GB) has no built-in cheat code menu or password system — the cartridge uses battery-backed save data. No officially documented button codes for stage select or invincibility exist for the retail cartridge.</p>
+    </div>
+  </section>
+
+  <footer>
+    <p>Donkey Kong (Game Boy) © 1994 Nintendo. Fan-made reference guide.</p>
+  </footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Covers controls, Mario's full expanded moveset (backflip, handstand,
long jump, ledge grab, throw), all nine worlds, tips and strategy,
and secrets (Pauline's accessories, hidden hearts, Super Game Boy
features, hammer score exploit). Includes retro-styled SVG placeholder
for the box art.

https://claude.ai/code/session_017Boi67XLwXKkxbrvJhtGEb